### PR TITLE
Fix an issue where blocks would break halfway or completely to the next column

### DIFF
--- a/public/css/web.css
+++ b/public/css/web.css
@@ -240,8 +240,7 @@ a.rail-news-title:hover {
     -webkit-column-break-inside: avoid;
     align-items: center;
     box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
+    display: block;
     margin-bottom: 5px;
     width: 100%;
 }


### PR DESCRIPTION
Resolved as [discussed](https://www.somda.nl/forum/23426/p730470/indeling-homepage-wordt-niet-onthouden/) in the actual forum.

See GIF of the result at [https://i.ibb.co/M1Xnp8b/Schermopname-2020-09-11-om-22-21-03.gif](https://i.ibb.co/M1Xnp8b/Schermopname-2020-09-11-om-22-21-03.gif)

Closes #5 