### PR TITLE
Database size reduction by creating a new table to store last read posts

### DIFF
--- a/database/empty_database/empty_forum_last_read.sql
+++ b/database/empty_database/empty_forum_last_read.sql
@@ -1,0 +1,12 @@
+--
+-- Tabelstructuur voor tabel `somda_forum_last_read`
+--
+
+CREATE TABLE IF NOT EXISTS `somda_forum_last_read` (
+  `uid` unsigned int(10) NOT NULL,
+  `discussionid` unsigned int(10) NOT NULL,
+  `postid` unsigned bigint(20) NOT NULL,
+  PRIMARY KEY (`uid`,`discussionid`),
+) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB
+
+-- --------------------------------------------------------

--- a/database/empty_database/fill_forum_last_read.sql
+++ b/database/empty_database/fill_forum_last_read.sql
@@ -1,0 +1,90 @@
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_0` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_1` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_2` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_3` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_4` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_5` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_6` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_7` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_8` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------
+INSERT IGNORE INTO `somda_forum_last_read` 
+  (`uid`, `discussionid`, `postid`)
+  SELECT `uid`, discussionid, max(r.postid)
+  from `somda_forum_read_9` r
+  left join `somda_forum_posts` p
+  on p.postid = r.postid
+  group by discussionid;
+
+-- --------------------------------------------------------

--- a/src/Controller/Api/ForumForumController.php
+++ b/src/Controller/Api/ForumForumController.php
@@ -140,6 +140,11 @@ class ForumForumController extends AbstractFOSRestController
      *                 type="string",
      *             ),
      *             @OA\Property(
+     *                 description="Identifier of the last post in the discussion read by the user",
+     *                 property="post_last_read",
+     *                 type="integer",
+     *             ),
+     *             @OA\Property(
      *                 description="Timestamp of the last post in this discussion (Y-m-d H:i:s)",
      *                 property="max_post_timestamp",
      *                 type="string",

--- a/src/Helpers/ForumOverviewHelper.php
+++ b/src/Helpers/ForumOverviewHelper.php
@@ -46,7 +46,7 @@ class ForumOverviewHelper
                 if ((int) $forum['type'] !== ForumForum::TYPE_ARCHIVE) {
                     $unreadDiscussions = $this->doctrine
                         ->getRepository(ForumForum::class)
-                        ->getNumberOfUnreadPostsInForum((int) $forum['id'], $this->userHelper->getUser());
+                        ->getNumberOfUnreadDiscussionsInForum((int) $forum['id'], $this->userHelper->getUser());
                 }
             } elseif ((int) $forum['type'] === ForumForum::TYPE_MODERATORS_ONLY) {
                 // Guest is not allowed to view this category

--- a/src/Repository/ForumDiscussion.php
+++ b/src/Repository/ForumDiscussion.php
@@ -319,8 +319,10 @@ class ForumDiscussion extends ServiceEntityRepository
 
     public function markAllPostsAsRead(User $user): void
     {
-        $query = 'INSERT IGNORE INTO `somda_forum_read_'  . \substr((string) $user->id, -1) . '` (postid, uid) ' .
-            ' SELECT postid, ' . (string) $user->id . ' FROM `somda_forum_posts`';
+        $query = 'REPLACE INTO `somda_forum_last_read` (uid, discussionid, postid) ' .
+            ' SELECT ' . (string) $user->id . ' as uid, d.discussionid, p.postid ' .
+            'FROM `somda_forum_discussion` d LEFT JOIN `somda_forum_posts` p ' .
+            'ON p.postid = (select postid from `somda_forum_posts` order by postid desc limit 1)';
 
         $connection = $this->getEntityManager()->getConnection();
         try {

--- a/src/Repository/ForumDiscussion.php
+++ b/src/Repository/ForumDiscussion.php
@@ -35,7 +35,7 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    `f`.`type` AS `forum_type`, TRUE AS `discussion_read`, `p_max`.`timestamp` AS `max_post_timestamp`,
+                    `f`.`type` AS `forum_type`, TRUE AS `discussion_read`, 0 AS `post_last_read`, `p_max`.`timestamp` AS `max_post_timestamp`,
                     COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
                 JOIN somda_forum_forums f ON f.forumid = d.forumid
@@ -53,14 +53,15 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    `f`.`type` AS `forum_type`, IF(`r`.`postid` IS NULL, FALSE, TRUE) AS `discussion_read`,
+                    `f`.`type` AS `forum_type`, IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+					IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                     `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
                 JOIN somda_forum_forums f ON f.forumid = d.forumid
                 JOIN somda_users a ON a.uid = d.authorid
                 JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
-                LEFT JOIN somda_forum_read_' . substr((string) $user->id, -1) . ' r
-                    ON r.uid = ' . (string) $user->id . ' AND r.postid = p_max.postid
+                LEFT JOIN somda_forum_last_read r
+                    ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
                 JOIN somda_forum_posts p_count ON p_count.discussionid = d.discussionid
                 INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
                 WHERE p_max.timestamp = m.max_date_time
@@ -98,7 +99,7 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    TRUE AS `discussion_read`, `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
+                    TRUE AS `discussion_read`, 0 AS `post_last_read`, `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
                 JOIN somda_users a ON a.uid = d.authorid
                 JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
@@ -111,13 +112,14 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    IF(`r`.`postid` IS NULL, FALSE, TRUE) AS `discussion_read`,
+                    IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+					IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                     `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
                 JOIN somda_users a ON a.uid = d.authorid
                 JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
-                LEFT JOIN somda_forum_read_' . substr((string) $user->id, -1) . ' r
-                    ON r.uid = ' . (string) $user->id . ' AND r.postid = p_max.postid
+                LEFT JOIN somda_forum_last_read r
+                    ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
                 JOIN somda_forum_posts p_count ON p_count.discussionid = d.discussionid
                 INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
                 WHERE d.forumid = :forumid AND p_max.timestamp = m.max_date_time
@@ -149,14 +151,15 @@ class ForumDiscussion extends ServiceEntityRepository
             SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                 `f`.`alerting` AS `alerting`,
                 `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                IF(`r`.`postid` IS NULL, FALSE, TRUE) AS `discussion_read`,
+                IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+				IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                 `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
             FROM somda_forum_discussion d
             JOIN somda_users a ON a.uid = d.authorid
             JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
             INNER JOIN somda_forum_favorites f ON f.discussionid = d.discussionid AND f.uid = :userId
-            LEFT JOIN somda_forum_read_' . substr((string) $user->id, -1) . ' r
-                ON r.uid = :userId AND r.postid = p_max.postid
+            LEFT JOIN somda_forum_last_read r
+                    ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
             JOIN somda_forum_posts p_count ON p_count.discussionid = d.discussionid
             INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
             WHERE p_max.timestamp = m.max_date_time
@@ -183,14 +186,15 @@ class ForumDiscussion extends ServiceEntityRepository
         $query = '
             SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                 `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                IF(`r`.`postid` IS NULL, FALSE, TRUE) AS `discussion_read`,
+                IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+				IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                 `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
             FROM somda_forum_discussion d
             JOIN somda_forum_forums f ON f.forumid = d.forumid
             JOIN somda_users a ON a.uid = d.authorid
             JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
-            LEFT JOIN somda_forum_read_' . substr((string) $user->id, -1) . ' r
-                ON r.uid = ' . (string) $user->id . ' AND r.postid = p_max.postid
+            LEFT JOIN somda_forum_last_read r
+                    ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
             JOIN somda_forum_posts p_count ON p_count.discussionid = d.discussionid
             INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
             WHERE p_max.timestamp = m.max_date_time AND f.type != :moderatorForumType AND `r`.`postid` IS NULL

--- a/src/Repository/ForumDiscussion.php
+++ b/src/Repository/ForumDiscussion.php
@@ -53,7 +53,7 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    `f`.`type` AS `forum_type`, IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+                    `f`.`type` AS `forum_type`, IF(IFNULL(`r`.`postid`, 0) < p_max.postid, FALSE, TRUE) AS `discussion_read`,
 					IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                     `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
@@ -112,7 +112,7 @@ class ForumDiscussion extends ServiceEntityRepository
             $query = '
                 SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                     `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                    IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+                    IF(IFNULL(`r`.`postid`, 0) < p_max.postid, FALSE, TRUE) AS `discussion_read`,
 					IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                     `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
                 FROM somda_forum_discussion d
@@ -151,7 +151,7 @@ class ForumDiscussion extends ServiceEntityRepository
             SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                 `f`.`alerting` AS `alerting`,
                 `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+                IF(IFNULL(`r`.`postid`, 0) < p_max.postid, FALSE, TRUE) AS `discussion_read`,
 				IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                 `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
             FROM somda_forum_discussion d
@@ -186,7 +186,7 @@ class ForumDiscussion extends ServiceEntityRepository
         $query = '
             SELECT `d`.`discussionid` AS `id`, `d`.`title` AS `title`, `a`.`uid` AS `author_id`,
                 `a`.`username` AS `author_username`, `d`.`locked` AS `locked`, `d`.`viewed` AS `viewed`,
-                IF(`r`.`postid` < p_max.postid, FALSE, TRUE) AS `discussion_read`,
+                FALSE AS `discussion_read`,
 				IFNULL(`r`.`postid`, 0) AS `post_last_read`,
                 `p_max`.`timestamp` AS `max_post_timestamp`, COUNT(*) AS `posts`
             FROM somda_forum_discussion d
@@ -197,7 +197,7 @@ class ForumDiscussion extends ServiceEntityRepository
                     ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
             JOIN somda_forum_posts p_count ON p_count.discussionid = d.discussionid
             INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
-            WHERE p_max.timestamp = m.max_date_time AND f.type != :moderatorForumType AND `r`.`postid` IS NULL
+            WHERE p_max.timestamp = m.max_date_time AND f.type != :moderatorForumType AND (`r`.`postid` IS NULL OR `r`.`postid` < p_max.postid)
             GROUP BY `id`, `title`, `author_id`, `viewed`, m.max_date_time, `discussion_read`, `max_post_timestamp`
             ORDER BY m.max_date_time DESC';
 

--- a/src/Repository/ForumForum.php
+++ b/src/Repository/ForumForum.php
@@ -51,12 +51,12 @@ class ForumForum extends ServiceEntityRepository
             WHERE d.forumid = :forumId
             GROUP BY disc_id';
         $query = '
-            SELECT SUM(IF(`r`.`postid` IS NULL, 1, 0)) AS `number_of_discussions_unread`
+            SELECT SUM(IF(IFNULL(`r`.`postid`, 0) < p_max.postid, 1, 0)) AS `number_of_discussions_unread`
             FROM somda_forum_discussion d
             JOIN somda_users a ON a.uid = d.authorid
             JOIN somda_forum_posts p_max ON p_max.discussionid = d.discussionid
-            LEFT JOIN somda_forum_read_' . substr((string) $user->id, -1) . ' r
-                ON r.uid = ' . (string) $user->id . ' AND r.postid = p_max.postid
+            LEFT JOIN somda_forum_last_read r
+                ON r.uid = ' . (string) $user->id . ' AND r.discussionid = d.discussionid
             INNER JOIN (' . $maxQuery . ') m ON m.disc_id = d.discussionid
             WHERE d.forumid = :forumId AND p_max.timestamp = m.max_date_time
             GROUP BY `d`.`forumid`';

--- a/src/Repository/ForumForum.php
+++ b/src/Repository/ForumForum.php
@@ -42,7 +42,7 @@ class ForumForum extends ServiceEntityRepository
         }
     }
 
-    public function getNumberOfUnreadPostsInForum(int $forumId, User $user): int
+    public function getNumberOfUnreadDiscussionsInForum(int $forumId, User $user): int
     {
         $maxQuery = '
             SELECT p.discussionid AS disc_id, MAX(p.timestamp) AS max_date_time


### PR DESCRIPTION
As discussed by e-mail, you can find this pull request. It should be tested before putting to production to verify if it is bug free.

A new table somda_forum_last_read is made. I provided two sql files to create this table and fill this table with existing data.
A cleanup can be done after migration to the new table structure.